### PR TITLE
Python3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: python
-
+python:
+  - "3.5"
 env:
-  - TOXENV=django19
+  - TOXENV=django19-py27
+  - TOXENV=django110-py27
+  - TOXENV=django110-py35
 
 install:
   - pip install tox

--- a/mote/models.py
+++ b/mote/models.py
@@ -78,7 +78,7 @@ class MetadataMixin(object):
                         try:
                             result[k] = json.loads(buf)
                         except ValueError:
-                            raise RuntimeError, "Invalid JSON at %s" % v
+                            raise RuntimeError("Invalid JSON at %s" % v)
             node = node._parent
         return result
 
@@ -175,8 +175,7 @@ class Element(MetadataMixin):
         if not os.path.exists(pth):
             return []
         li = [Variation(id, self) for id in os.listdir(pth) if not id.startswith(".") and not id in RESERVED_IDS]
-        li.sort(lambda a, b: cmp(a.metadata.get("position"), b.metadata.get("position")))
-        return li
+        return sorted(li, key=lambda item: item.metadata.get("position"))
 
     @property
     def modified(self):
@@ -210,8 +209,7 @@ class Pattern(MetadataMixin):
     @cached_property
     def elements(self):
         li = [Element(id, self) for id in os.listdir(self._root) if not id.startswith(".") and not id in RESERVED_IDS]
-        li.sort(lambda a, b: cmp(a.metadata.get("position"), b.metadata.get("position")))
-        return li
+        return sorted(li, key=lambda item: item.metadata.get("position"))
 
     def __getattr__(self, key):
         """Allow element lookup by name"""
@@ -242,8 +240,7 @@ class Aspect(MetadataMixin):
     @cached_property
     def patterns(self):
         li = [Pattern(id, self) for id in os.listdir(os.path.join(self._root, "src", "patterns")) if not id.startswith(".") and not id in RESERVED_IDS]
-        li.sort(lambda a, b: cmp(a.metadata.get("position"), b.metadata.get("position")))
-        return li
+        return sorted(li, key=lambda item: item.metadata.get("position"))
 
     def __getattr__(self, key):
         """Allow pattern lookup by name"""
@@ -261,8 +258,7 @@ class Project(MetadataMixin):
     @cached_property
     def aspects(self):
         li = [Aspect(id, self) for id in os.listdir(self._root) if not id.startswith(".") and not id in RESERVED_IDS]
-        li.sort(lambda a, b: cmp(a.metadata.get("position"), b.metadata.get("position")))
-        return li
+        return sorted(li, key=lambda item: item.metadata.get("position"))
 
     def __getattr__(self, key):
         """Allow aspect lookup by name"""

--- a/mote/templatetags/mote_tags.py
+++ b/mote/templatetags/mote_tags.py
@@ -1,6 +1,5 @@
 import re
 import json
-import types
 from hashlib import md5
 
 from bs4 import BeautifulSoup

--- a/mote/templatetags/mote_tags.py
+++ b/mote/templatetags/mote_tags.py
@@ -1,7 +1,7 @@
 import re
-import md5
 import json
 import types
+from hashlib import md5
 
 from bs4 import BeautifulSoup
 import xmltodict
@@ -15,6 +15,7 @@ from django.template.loader import render_to_string
 from django.template.response import TemplateResponse
 from django.utils.translation import ugettext as _
 from django.utils.functional import Promise
+from django.utils.six import string_types, text_type
 from django.conf import settings
 
 from mote.utils import deepmerge, deephash
@@ -56,7 +57,7 @@ class RenderElementNode(template.Node):
         element_or_identifier = self.element_or_identifier.resolve(context)
 
         # If element_or_identifier is a string convert it
-        if isinstance(element_or_identifier, (unicode, str)):
+        if isinstance(element_or_identifier, string_types):
             parts = element_or_identifier.split(".")
             length = len(parts)
             if length not in (4, 5):
@@ -80,10 +81,10 @@ class RenderElementNode(template.Node):
             except VariableDoesNotExist:
                 continue
             if isinstance(r, Promise):
-                r = unicode(r)
+                r = text_type(r)
 
             # Strings may be interpreted further
-            if isinstance(r, (unicode, str)):
+            if isinstance(r, string_types):
 
                 # Attempt to resolve any variables by rendering
                 t = template.Template(r)
@@ -119,7 +120,7 @@ class RenderElementNode(template.Node):
         # Compute a cache key
         li = [obj.modified, deephash(resolved)]
         li.extend(frozenset(sorted(view_kwargs.items())))
-        hashed = md5.new(':'.join([str(l) for l in li])).hexdigest()
+        hashed = md5(u':'.join([text_type(l) for l in li]).encode('utf-8')).hexdigest()
         cache_key = 'render-element-%s' % hashed
 
         cached = cache.get(cache_key, None)
@@ -218,7 +219,7 @@ class ResolveNode(template.Node):
             except VariableDoesNotExist:
                 continue
             if isinstance(r, Promise):
-                r = unicode(r)
+                r = text_type(r)
             return r
         return ""
 
@@ -282,7 +283,7 @@ class GetElementDataNode(template.Node):
         )
 
         # Discard the root node
-        di = di[di.keys()[0]]
+        di = di[list(di.keys())[0]]
 
         # In debug mode use expensive conversion for easy debugging
         if settings.DEBUG:

--- a/mote/utils.py
+++ b/mote/utils.py
@@ -1,4 +1,3 @@
-import types
 from copy import deepcopy
 
 
@@ -8,21 +7,21 @@ def _deepmerge(source, delta):
     for key, value in delta.items():
 
         if isinstance(value, dict):
-            if (key in source) and isinstance(source[key], types.ListType):
+            if (key in source) and isinstance(source[key], list):
                 # We expect a list but didn"t get one. Do conversion.
                 _deepmerge(source, {key: [value]})
             else:
                 node = source.setdefault(key, {})
                 _deepmerge(node, value)
 
-        elif (key in source) and isinstance(value, types.ListType):
+        elif (key in source) and isinstance(value, list):
             # Use the zero-th item as an archetype
             el = deepcopy(source[key][0])
             source[key] = []
             for n in value:
                 source[key].append(deepcopy(el))
             for n, v in enumerate(value):
-                if isinstance(v, types.DictType):
+                if isinstance(v, dict):
                     _deepmerge(source[key][n], v)
                 else:
                     source[key][n] = v

--- a/mote/views.py
+++ b/mote/views.py
@@ -19,9 +19,8 @@ class HomeView(TemplateView):
         context = super(HomeView, self).get_context_data(**kwargs)
         li = []
         for id, pth in PROJECT_PATHS.items():
-			li.append(Project(id))
-        li.sort(lambda a, b: cmp(a.metadata.get("position"), a.metadata.get("position")))
-        context["projects"] = li
+            li.append(Project(id))
+        context["projects"] = sorted(li, key=lambda item: item.metadata.get("position"))
         return context
 
 

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         "ujson",
         "six",
         "djangorestframework-jwt",
+        "djangorestframework",
         "xmltodict"
     ],
     tests_require=[

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,21 @@
 [tox]
 envlist =
-    django19
-    django110
+    django19-py27
+    django110-py27
+    django110-py35
 
 [testenv]
 basepython = python2.7
 
-[testenv:django19]
+[testenv:django19-py27]
 deps = -rmote/tests/requirements/19.txt
 commands = python manage.py test mote{posargs} --settings=mote.tests.settings.19
 
-[testenv:django110]
+[testenv:django110-py27]
+deps = -rmote/tests/requirements/110.txt
+commands = python manage.py test mote{posargs} --settings=mote.tests.settings.110
+
+[testenv:django110-py35]
+basepython = python3.5
 deps = -rmote/tests/requirements/110.txt
 commands = python manage.py test mote{posargs} --settings=mote.tests.settings.110


### PR DESCRIPTION
Added Python3.5 support.
Updated travis/tox tests to test against django 1.10 as well (for both 2.7 and 3.5).
Added "djangorestframework" to dependencies manually as for some reason "djangorestframework-jwt" didn't pull it in.