### PR TITLE
Added trim filter to mote_tags.py

### DIFF
--- a/mote/templatetags/mote_tags.py
+++ b/mote/templatetags/mote_tags.py
@@ -12,6 +12,7 @@ from django.conf import settings
 from django.core.cache import cache
 from django.http import HttpResponse
 from django import template
+from django.template.defaultfilters import stringfilter
 from django.template.base import VariableDoesNotExist
 from django.template.loader import render_to_string
 from django.template.response import TemplateResponse
@@ -30,6 +31,14 @@ from mote.views import ElementPartialView, VariationPartialView,\
 
 register = template.Library()
 
+# Under certain conditions Mote on Linux
+# emits strings with both leading and trailing
+# whitespace. This filter gives us a way of
+# removing that whitespace.
+@register.filter
+@stringfilter
+def trim(value):
+    return value.strip()
 
 @register.tag
 def render(parser, token):


### PR DESCRIPTION
This is a weird one, and maybe there is a better solution out there.

We were having an issue where Mote running on a Linux box was emitting strings with leading and trailing whitespace, so we needed a way of sanitising that output on the server side. Hence I added this.

Using `.strip` was out of the question, as mote relies on `.` to traverse the data, and as such it had to be a filter as per this StackOverflow answer: https://stackoverflow.com/questions/10361240/template-filter-to-trim-any-leading-or-trailing-whitespace